### PR TITLE
Fix multiselect for handsontable 7 1 1

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -60,7 +60,7 @@ function customDropdownRenderer(instance, td, row, col, prop, value, cellPropert
     var optionsList = cellProperties.chosenOptions.data;
 
     if(typeof optionsList === "undefined" || typeof optionsList.length === "undefined" || !optionsList.length) {
-        Handsontable.cellTypes.text.renderer(instance, td, row, col, prop, value, cellProperties);
+        Handsontable.renderers.TextRenderer.apply(this, arguments);
         return td;
     }
 
@@ -75,6 +75,6 @@ function customDropdownRenderer(instance, td, row, col, prop, value, cellPropert
     }
     value = value.join(", ");
 
-    Handsontable.cellTypes.text.renderer(instance, td, row, col, prop, value, cellProperties);
+    Handsontable.renderers.TextRenderer.apply(this, arguments);
     return td;
 }

--- a/handsontable-chosen-editor.js
+++ b/handsontable-chosen-editor.js
@@ -260,7 +260,7 @@
         if(!this.$textarea.val()) {
             return "";
         }
-        if(typeof this.$textarea.val() === "object") {
+        if(typeof this.$textarea.val() === "object" && !this.cellProperties.chosenOptions.multiple) {
             return this.$textarea.val().join(",");
         }
         return this.$textarea.val();

--- a/index.html
+++ b/index.html
@@ -7,15 +7,15 @@
 
     <link rel="stylesheet prefetch" href="https://cdnjs.cloudflare.com/ajax/libs/chosen/1.4.2/chosen.css">
     <link rel="stylesheet prefetch"
-          href="https://cdnjs.cloudflare.com/ajax/libs/handsontable/0.19.0/handsontable.full.css">
+          href="https://cdnjs.cloudflare.com/ajax/libs/handsontable/7.1.1/handsontable.full.css">
 </head>
 <body>
 
 <div id="handsontable"></div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/chosen/1.4.2/chosen.jquery.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/handsontable/0.19.0/handsontable.full.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handsontable/7.1.1/handsontable.full.js"></script>
 <script src="handsontable-chosen-editor.js"></script>
 <script src="demo.js"></script>
 </body>


### PR DESCRIPTION
Updated demo to use the most recent version of chosen, jquery and handsontable.  

Changed getValue method to return an array of items instead of a comma separated string to work with Rails. 5.2.x.